### PR TITLE
Switch to a path identifier for yml files to define variants.

### DIFF
--- a/aln2type/aln2type.py
+++ b/aln2type/aln2type.py
@@ -12,6 +12,7 @@ from itertools import groupby, product
 from collections import OrderedDict
 import json
 import gzip
+import glob
 
 
 def iupac_to_base(base):
@@ -513,7 +514,7 @@ def go(args):
         sys.exit(1)
 
     variant_types = []
-    for scheme in args.typing_yaml:
+    for scheme in glob.glob(args.typing_yaml + "**/*.yml", recursive=True):
         variant_types.append(read_scheme_yaml(scheme))
 
     typing_summary = []

--- a/aln2type/cli.py
+++ b/aln2type/cli.py
@@ -10,7 +10,7 @@ def parse_args():
     parser.add_argument("summary_csv_outfile", help="Output summary CSV file")
     parser.add_argument("ref_name", help="Name of reference sequence in MSA")
     parser.add_argument("msa", help="Path to MSA")
-    parser.add_argument("typing_yaml", nargs='+', help="Path to Variant definition YAML files")
+    parser.add_argument("typing_yaml", help="Path to Variant definition YAML files")
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
Previous pull request didn't actually work...

This changes the behaviour of the typing_yaml argument to make it read the contents of a folder and find all .yml files within it. This may not be the desired behaviour but matches the original written description of the argument.

However, it does prevent users from explicitly checking against just one variant definition yml.